### PR TITLE
fix: shorten description for Marketplace, add cron Slack blocks

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,5 @@
 name: Devin Reminders Action
-description: |
-  Schedule, list, and fire reminders for Devin.ai sessions.
-  Stores reminders as GitHub Actions artifacts and fires them via aaronsteers/devin-action.
+description: "Schedule, list, and fire reminders for Devin.ai sessions."
 branding:
   icon: bell
   color: purple
@@ -213,12 +211,16 @@ runs:
 
         test -n "${CURRENT_JSON}" || CURRENT_JSON="[]"
 
+        SESSION_ID="$(echo "${AGENT_SESSION_URL}" | sed -E 's#.*/sessions/([^/?]+).*#\1#')"
+        SESSION_ID_SHORT="${SESSION_ID:0:8}"
+
         NEW_ITEM="$(jq -n \
           --arg guid "${ITEM_GUID}" \
           --arg msg "${REMINDER_MESSAGE}" \
           --arg url "${AGENT_SESSION_URL}" \
           --arg remind "${REMIND_AT}" \
           --arg human "${HUMAN_USER}" \
+          --arg sid_short "${SESSION_ID_SHORT}" \
           --arg created "$(date -u +%Y-%m-%dT%H:%M:%S+00:00)" \
           '{
             guid: $guid,
@@ -226,7 +228,8 @@ runs:
             agent_session_url: $url,
             remind_at: $remind,
             created_at: $created,
-            human_user: (if $human == "" then null else $human end)
+            human_user: (if $human == "" then null else $human end),
+            session_id_short: $sid_short
           }')"
 
         UPDATED="$(echo "${CURRENT_JSON}" | jq -c --argjson item "${NEW_ITEM}" '. + [$item]')"
@@ -307,6 +310,11 @@ runs:
           GUID="$(echo "${ITEM}" | jq -r '.guid')"
           MSG="$(echo "${ITEM}" | jq -r '.reminder_message')"
           SESSION_URL="$(echo "${ITEM}" | jq -r '.agent_session_url')"
+          SID_SHORT="$(echo "${ITEM}" | jq -r '.session_id_short // empty')"
+          if [ -z "${SID_SHORT}" ]; then
+            SESSION_ID="$(echo "${SESSION_URL}" | sed -E 's#.*/sessions/([^/?]+).*#\1#')"
+            SID_SHORT="${SESSION_ID:0:8}"
+          fi
 
           echo "Firing reminder ${GUID}: ${MSG}"
 
@@ -369,16 +377,33 @@ runs:
           MSG="$(echo "${ITEM}" | jq -r '.reminder_message')"
           SESSION_URL="$(echo "${ITEM}" | jq -r '.agent_session_url')"
           HUMAN="$(echo "${ITEM}" | jq -r '.human_user // empty')"
+          SID_SHORT="$(echo "${ITEM}" | jq -r '.session_id_short // empty')"
+          if [ -z "${SID_SHORT}" ]; then
+            SESSION_ID="$(echo "${SESSION_URL}" | sed -E 's#.*/sessions/([^/?]+).*#\1#')"
+            SID_SHORT="${SESSION_ID:0:8}"
+          fi
 
-          TEXT="Reminder delivered: ${MSG}\nSession: ${SESSION_URL}"
+          CC_LINE=""
           if [ -n "${HUMAN}" ]; then
-            TEXT="${TEXT}\nCC: ${HUMAN}"
+            CC_LINE="\nCC: ${HUMAN}"
           fi
 
           PAYLOAD="$(jq -n \
             --arg channel "${SLACK_CHANNEL}" \
-            --arg text "${TEXT}" \
-            '{channel: $channel, unfurl_links: false, unfurl_media: false, text: $text}')"
+            --arg msg "${MSG}" \
+            --arg url "${SESSION_URL}" \
+            --arg sid "${SID_SHORT}" \
+            --arg cc "${CC_LINE}" \
+            '{
+              channel: $channel,
+              unfurl_links: false,
+              unfurl_media: false,
+              blocks: [
+                {type: "section", text: {type: "mrkdwn", text: ":bell: Devin reminder delivered:"}},
+                {type: "section", text: {type: "mrkdwn", text: ("> *" + $msg + "*")}},
+                {type: "context", elements: [{type: "mrkdwn", text: ("Sent by <http://Devin.ai|Devin.ai> (No-Reply) from session <" + $url + "|" + $sid + ">." + $cc)}]}
+              ]
+            }')"
 
           curl -sf -X POST \
             -H "Authorization: Bearer ${SLACK_TOKEN}" \


### PR DESCRIPTION
## Summary

Three changes:

1. **Shorten `description` in `action.yml`** to fit GitHub Marketplace's 125-character limit (was a multi-line string that exceeded the limit, blocking release publishing).

2. **Persist `session_id_short` in reminder item JSON** — the put step now stores the first 8 characters of the session UUID in each reminder record. The cron step reads it from the item (with a fallback extraction from the URL for backward compatibility with pre-existing reminders).

3. **Upgrade cron Slack notification to blocks format** — matches the put notification style and the upstream pattern from [airbytehq/airbyte-ops-mcp#372](https://github.com/airbytehq/airbyte-ops-mcp/pull/372). Uses `:bell:` emoji header, bold quoted message, and a context block with a short session link.

## Review & Testing Checklist for Human

- [ ] **Cron Slack blocks payload**: The `CC_LINE` variable contains a literal `\n` string passed via `jq --arg`. Verify Slack mrkdwn in blocks interprets `\n` as a line break (it should, but worth confirming with a real notification).
- [ ] **`session_id_short` extraction regex** is now duplicated in 3 places (resolve step, put-build step, cron fallback). Consider whether to consolidate, or accept the duplication for clarity.
- [ ] **End-to-end test**: CI only covers `action: list` on empty state. Recommend manually testing `put` → `cron` → Slack to verify the new blocks format renders correctly and `session_id_short` round-trips through the artifact.

**Suggested test plan:** Trigger `workflow_dispatch` with `action: put`, a `remind-at` ~30 min in the future, and a `slack-channel` set. Confirm the artifact JSON contains `session_id_short`. After the time passes, trigger `action: cron` and verify the Slack notification uses the `:bell:` blocks format with the short session link.

### Notes

- The put notification uses `:pushpin:` while the cron notification uses `:bell:` — this is intentional (scheduled vs. delivered).
- Backward-compatible: reminders created before this change will still work; the cron step falls back to extracting `session_id_short` from the URL if the field is missing.

Requested by: @aaronsteers
Link to Devin run: https://app.devin.ai/sessions/9790416f1f0945beb9a9cdd30a5e81b1
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aaronsteers/devin-reminders-action/pull/2" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
