### PR TITLE
feat: add org-id input for v3 API support

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,11 @@ inputs:
       JSON array of reminder GUIDs to cancel (required for 'cancel' action).
       Example: '["abc-123", "def-456"]'
     required: false
+  org-id:
+    description: >
+      Devin organization ID (required for v3 API). When set, the action uses
+      v3 org-scoped endpoints instead of v1.
+    required: false
   lock-mode:
     description: >
       Controls artifact-based locking to prevent race conditions.
@@ -437,6 +442,7 @@ runs:
       env:
         DUE_JSON: ${{ steps.list.outputs.due_json }}
         DEVIN_TOKEN: ${{ inputs.devin-token }}
+        ORG_ID: ${{ inputs.org-id }}
       run: |
         set -euo pipefail
 
@@ -472,11 +478,19 @@ runs:
               "message": $message
             }')"
 
+          # Use v3 org-scoped endpoint when org-id is provided, otherwise fall back to v1
+          if [ -n "${ORG_ID}" ]; then
+            DEVIN_ID="devin-${SESSION_ID}"
+            API_URL="https://api.devin.ai/v3/organizations/${ORG_ID}/sessions/${DEVIN_ID}/messages"
+          else
+            API_URL="https://api.devin.ai/v1/sessions/${SESSION_ID}/message"
+          fi
+
           RESPONSE="$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST \
             -H "Authorization: Bearer ${DEVIN_TOKEN}" \
             -H "Content-Type: application/json" \
             -d "${PAYLOAD}" \
-            "https://api.devin.ai/v1/sessions/${SESSION_ID}/message" 2>&1)"
+            "${API_URL}" 2>&1)"
 
           HTTP_STATUS="$(echo "${RESPONSE}" | grep "HTTP_STATUS:" | cut -d':' -f2)"
           RESPONSE_BODY="$(echo "${RESPONSE}" | sed '/HTTP_STATUS:/d')"


### PR DESCRIPTION
## Summary

Adds an optional `org-id` input so the action can use Devin's v3 org-scoped API endpoint for firing reminders. When `org-id` is provided, the cron step sends messages to:

```
POST /v3/organizations/{org_id}/sessions/devin-{session_id}/messages
```

When omitted, the existing v1 endpoint is used unchanged, preserving backward compatibility.

**Context:** The Devin API key used in `airbyte-ops-mcp` was switched to a v3 service account token, which returns 403 on v1 endpoints. This fix unblocks the reminders cron job.

## Review & Testing Checklist for Human

- [ ] **v3 endpoint URL correctness** — Verify that `/v3/organizations/{org_id}/sessions/devin-{session_id}/messages` is the correct path. The v3 docs show `devin_id` should be the session ID prefixed with `devin-` and the path ends in `/messages` (plural, unlike v1's `/message`). Confirm the request body schema (`{"message": "..."}`) is unchanged between v1 and v3.
- [ ] **Live test** — After merging, update `devin-reminders.yml` in `airbyte-ops-mcp` to pass `org-id: ${{ vars.DEVIN_AI_ORG_ID }}` and trigger a cron run (or wait for the next 30-min schedule). Verify at least one reminder fires without a 403.
- [ ] **Double-prefix edge case** — The code assumes `SESSION_ID` extracted from the session URL does *not* already contain a `devin-` prefix. Confirm session URLs always use the raw hex ID (e.g., `https://app.devin.ai/sessions/abc123...`), not `devin-abc123...`.

### Notes

- Only the cron (fire) step is affected; `put`, `list`, and `cancel` actions don't call the Devin API directly so they don't need `org-id`.
- A follow-up PR in `airbyte-ops-mcp` is needed to actually pass the `org-id` input and pin to the new version/`@main`.

Link to Devin session: https://app.devin.ai/sessions/151617914e3c4c83825f4db701f8feff
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aaronsteers/devin-reminders-action/pull/12" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
