### PR TITLE
fix: fail workflow when reminders fail to fire

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -83,6 +83,9 @@ outputs:
   popped-count:
     description: "Number of reminders removed after cron firing"
     value: ${{ steps.pop.outputs.popped_count }}
+  failed-count:
+    description: "Number of reminders that failed to fire (only set for cron action)"
+    value: ${{ steps.cron.outputs.failed_count }}
   cancelled-count:
     description: "Number of reminders cancelled (only set for cancel action)"
     value: ${{ steps.cancel-build.outputs.cancelled_count }}
@@ -450,6 +453,7 @@ runs:
         echo "Processing ${DUE_COUNT} due reminder(s)..."
 
         FIRED_GUIDS="[]"
+        FAILED_GUIDS="[]"
 
         for i in $(seq 0 $(( DUE_COUNT - 1 ))); do
           ITEM="$(echo "${DUE_JSON}" | jq -c ".[$i]")"
@@ -503,7 +507,8 @@ runs:
           fi
 
           if [ "${RESPONSE}" = "API_CALL_FAILED" ]; then
-            echo "::warning::Failed to fire reminder ${GUID}"
+            echo "::error::Failed to fire reminder ${GUID}"
+            FAILED_GUIDS="$(echo "${FAILED_GUIDS}" | jq -c --arg g "${GUID}" '. + [$g]')"
           else
             echo "Reminder ${GUID} fired successfully"
             echo "Response: ${RESPONSE}"
@@ -514,6 +519,10 @@ runs:
         echo "fired_guids=$(echo "${FIRED_GUIDS}" | jq -c .)" | tee -a "$GITHUB_OUTPUT"
         FIRED_COUNT="$(echo "${FIRED_GUIDS}" | jq 'length')"
         echo "fired_count=${FIRED_COUNT}" | tee -a "$GITHUB_OUTPUT"
+
+        echo "failed_guids=$(echo "${FAILED_GUIDS}" | jq -c .)" | tee -a "$GITHUB_OUTPUT"
+        FAILED_COUNT="$(echo "${FAILED_GUIDS}" | jq 'length')"
+        echo "failed_count=${FAILED_COUNT}" | tee -a "$GITHUB_OUTPUT"
 
     - name: Slack notification (cron)
       if: steps.resolve.outputs.is_cron == 'true' && steps.cron.outputs.fired_count != '0' && steps.cron.outputs.fired_count != '' && inputs.slack-channel != ''
@@ -622,5 +631,12 @@ runs:
         if [ "${{ steps.list.outputs.due_count }}" = "0" ]; then
           echo "🔔 **Cron** at \`${{ steps.resolve.outputs.now }}\` — total ${{ steps.list.outputs.total_count }}, due 0." | tee -a "$GITHUB_STEP_SUMMARY"
         else
-          echo -e "🔔 **Cron** at \`${{ steps.resolve.outputs.now }}\`\n- total: ${{ steps.list.outputs.total_count }}\n- due: ${{ steps.list.outputs.due_count }}\n- fired: ${{ steps.cron.outputs.fired_count }}\n- popped: ${{ steps.pop.outputs.popped_count }}\n- remaining: ${{ steps.pop.outputs.remaining_count }}" | tee -a "$GITHUB_STEP_SUMMARY"
+          echo -e "🔔 **Cron** at \`${{ steps.resolve.outputs.now }}\`\n- total: ${{ steps.list.outputs.total_count }}\n- due: ${{ steps.list.outputs.due_count }}\n- fired: ${{ steps.cron.outputs.fired_count }}\n- failed: ${{ steps.cron.outputs.failed_count }}\n- popped: ${{ steps.pop.outputs.popped_count }}\n- remaining: ${{ steps.pop.outputs.remaining_count }}" | tee -a "$GITHUB_STEP_SUMMARY"
         fi
+
+    - name: Fail if any reminders could not be delivered
+      if: steps.resolve.outputs.is_cron == 'true' && steps.cron.outputs.failed_count != '0' && steps.cron.outputs.failed_count != ''
+      shell: bash
+      run: |
+        echo "::error::${{ steps.cron.outputs.failed_count }} reminder(s) failed to fire. Failed GUIDs: ${{ steps.cron.outputs.failed_guids }}"
+        exit 1


### PR DESCRIPTION
## Summary

Previously, failed reminder deliveries were logged as `::warning::` and the workflow exited green. Now the workflow exits non-zero when any reminder fails to fire, making failures visible in the Actions UI.

Changes:
- Track `FAILED_GUIDS` alongside `FIRED_GUIDS` in the cron step
- Escalate failed-fire log from `::warning::` to `::error::`
- Add a final step that `exit 1` if `failed_count > 0`
- Expose `failed-count` as a new action output
- Include failed count in the step summary

The failure step runs *after* Slack notifications, artifact pop/upload, and lock release, so cleanup is not interrupted.

## Review & Testing Checklist for Human

- [ ] **Stale reminders will cause perpetual red builds.** Failed reminders are *not* popped — only successfully fired ones are. This means reminders targeting exited sessions (like the current batch of `"Session already exited"` errors) will retry every 30 minutes and fail every time until they expire from the artifact (4-day retention) or are manually cancelled via `action: cancel`. Decide whether this is the desired behavior or whether failed reminders should also be popped (or popped after N retries).
- [ ] **`set -euo pipefail` vs curl failures.** If `curl` itself errors (e.g., DNS failure, network timeout — not an HTTP 400/403), `set -e` will kill the cron step before `failed_count`/`fired_count` outputs are written. This is a pre-existing issue, not introduced here, but worth noting since the new failure step depends on those outputs being set.
- [ ] **Test plan:** Trigger `workflow_dispatch` with `action: cron` on the ops-mcp workflow pointing at this branch. If there are still stale reminders in the artifact, the run should now show red with `::error::` annotations. Verify the step summary includes the `failed` line and that the lock is still released correctly.

### Notes

- The existing stale reminders (targeting sessions `7c2f7538...` and `366f895f...`) will immediately start causing red builds once this is merged. You may want to cancel them first via `action: cancel` or accept the noise until artifact expiry.

Link to Devin session: https://app.devin.ai/sessions/151617914e3c4c83825f4db701f8feff
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aaronsteers/devin-reminders-action/pull/13" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
