### PR TITLE
fix: purge expired lock artifacts before acquiring the reminders lock

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -207,6 +207,30 @@ runs:
 
         echo "Validation passed."
 
+    - name: Purge expired lock artifacts
+      if: >
+        (inputs.lock-mode == 'always') ||
+        (inputs.lock-mode == 'auto' && steps.resolve.outputs.is_list != 'true')
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+
+        # Expired artifacts stay listed by the artifacts API, and the lock action
+        # treats any listed artifact as a held lock, so an expired lock deadlocks
+        # every subsequent run until it is deleted.
+        RESULT=$(curl -s -H "Authorization: Bearer ${GH_TOKEN}" \
+          "https://api.github.com/repos/${{ github.repository }}/actions/artifacts?name=devin-reminders-lock&per_page=100")
+        EXPIRED_IDS=$(echo "${RESULT}" | jq -r '.artifacts[] | select(.expired == true) | .id')
+
+        for artifact_id in ${EXPIRED_IDS}; do
+          echo "Deleting expired lock artifact ${artifact_id}"
+          curl -s -X DELETE -H "Authorization: Bearer ${GH_TOKEN}" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/artifacts/${artifact_id}" \
+            || echo "::warning::Could not delete expired lock artifact ${artifact_id}"
+        done
+
     - name: Acquire artifact lock
       id: lock-acquire
       if: >

--- a/action.yml
+++ b/action.yml
@@ -226,7 +226,7 @@ runs:
 
         for artifact_id in ${EXPIRED_IDS}; do
           echo "Deleting expired lock artifact ${artifact_id}"
-          curl -s -X DELETE -H "Authorization: Bearer ${GH_TOKEN}" \
+          curl -fsS -X DELETE -H "Authorization: Bearer ${GH_TOKEN}" \
             "https://api.github.com/repos/${{ github.repository }}/actions/artifacts/${artifact_id}" \
             || echo "::warning::Could not delete expired lock artifact ${artifact_id}"
         done


### PR DESCRIPTION
## Summary

An expired `devin-reminders-lock` artifact deadlocks the action forever. GitHub keeps expired artifacts in the artifacts API listing, and `guibranco/github-artifact-lock-action` reads `.artifacts[0].id` with no `expired` filter, so it reports "Lock is still held. Found artifact with ID: …", retries 30×, and fails — on every run, indefinitely. Observed in `airbytehq/airbyte-ops-mcp`: artifact `9292007932` (created 2026-08-17, `expired: true`) has failed every `put` and every 30-minute `cron` run since then, and the `devin-reminders` state artifact aged out in the meantime, silently dropping all pending reminders.

The fix adds a step ahead of `Acquire artifact lock`, gated on the same `lock-mode` condition, that deletes expired lock artifacts:

```bash
EXPIRED_IDS=$(... artifacts?name=devin-reminders-lock ... | jq -r '.artifacts[] | select(.expired == true) | .id')
for artifact_id in ${EXPIRED_IDS}; do DELETE /actions/artifacts/${artifact_id}; done
```

This mirrors the `select(.expired == false)` filter the action already applies in `Find latest artifact run`. Deletion failures only warn — a caller whose job grants `actions: read` (possible under `lock-mode: always`) still proceeds to the acquire step rather than failing.

Note this unblocks the deadlock but does not remove the underlying sharp edge: a *live* lock artifact orphaned by a cancelled run still blocks until it expires. A `lock-mode` escape hatch or a max-lock-age override would cover that case.


Link to Devin session: https://app.devin.ai/sessions/9e47a11767224914a500b134c394adc4
Requested by: @aaronsteers